### PR TITLE
Added "slime property" prefix to property expression

### DIFF
--- a/src/main/kotlin/dev/danielmillar/slimelink/skript/expressions/ExprModifySlimeProperties.kt
+++ b/src/main/kotlin/dev/danielmillar/slimelink/skript/expressions/ExprModifySlimeProperties.kt
@@ -21,8 +21,8 @@ import org.bukkit.event.Event
 @Description("Modify a property value in a SlimePropertyMap.")
 @Examples(
     value = [
-        "set pvp of {_slimeProperty} to true",
-        "set spawn x of {_slimeProperty} to 100"
+        "set slime property pvp of {_slimeProperty} to true",
+        "set slime property spawn x of {_slimeProperty} to 100"
     ]
 )
 @Since("1.0.0")
@@ -34,7 +34,7 @@ class ExprModifySlimeProperties : SimpleExpression<Any>() {
                 ExprModifySlimeProperties::class.java,
                 Any::class.java,
                 ExpressionType.SIMPLE,
-                "%slimeproperty% of %slimepropertymap%"
+                "slime property %slimeproperty% of %slimepropertymap%"
             )
         }
     }


### PR DESCRIPTION
The pattern `%slimeproperty% of %slimepropertymap%` is not safe as it potentially overrides all of skript's "of" expressions.
I had an issue with this since doing `world of {_p::*}` would end up in an error related to this.
<img width="903" height="108" alt="image" src="https://github.com/user-attachments/assets/a2e109a7-3196-416f-ae0e-5dd725fd7e8f" />
